### PR TITLE
minimize allocations in evalh routines

### DIFF
--- a/contdef1d/bench_Cont1DBZ.jl
+++ b/contdef1d/bench_Cont1DBZ.jl
@@ -30,6 +30,8 @@ for M = [1,10,100]
     
     @printf "\tQuadr meths:\nrealadap ω=%g η=%g tol=%g:  " ω η tol
     @btime realadap($hm,ω,η,tol=tol)
+    @printf "\tQuadr meths:\nrealadap_lxvm ω=%g η=%g tol=%g:  " ω η tol
+    @btime realadap_lxvm($hm,ω,η,tol=tol)
     @printf "roots (matrix size 2M+1=%d):  " 2M+1
     coeffs = reverse(hm.parent)
     @btime roots($coeffs)

--- a/contdef1d/bench_Cont1DBZ.jl
+++ b/contdef1d/bench_Cont1DBZ.jl
@@ -27,6 +27,8 @@ for M = [1,10,100]
     @btime evalh($hm,$x)        # why so many allocs & RAM?
     t_ns = minimum((@benchmark evalh($hm,$x)).times)
     @printf "evalh %g G mode-targs/sec\n" (2M+1)*length(x)/t_ns
+    @printf "fourier_kernel:    \t"
+    @btime map(x -> fourier_kernel($hm,x), $x)
     
     @printf "\tQuadr meths:\nrealadap ω=%g η=%g tol=%g:  " ω η tol
     @btime realadap($hm,ω,η,tol=tol)

--- a/contdef1d/test_Cont1DBZ.jl
+++ b/contdef1d/test_Cont1DBZ.jl
@@ -23,6 +23,7 @@ for t=1:length(xtest)
     end
     @printf "evalh chk: %g\n" norm(evalh(hm,x) .- evalh_ref(hm,x),Inf)
     @printf "evalh_wind chk: %g\n" norm(evalh_wind(hm,x) .- evalh_ref(hm,x),Inf)
+    @printf "fourier_kernel chk: %g\n" norm(fourier_kernel.(Ref(hm),x) .- evalh_ref(hm,x),Inf)
 end
 
 η=1e-6; ω=0.5; tol=1e-8;


### PR DESCRIPTION
This pr minimizes the number of allocations in the `evalh_wind` and `evalh` routines, which saves ~2 microseconds in the benchmarks. Generally, there were extra allocations because of inconsistent usage of the dot syntax (e.g. writing `exp.(im*x)` instead of `exp.(im .* x)`, where the latter fuses the broadcast calls) as well as from allocating separate real/imag arrays. It also replaces `exp(im*x)` with `cis(x)`, which also saves ~5 microseconds in the benchmarks. These changes led to a performance regression in `evalh` for large `M` that is likely due to my incomplete understanding of the assumptions used by the `@avx` macro in relation to complex arithmetic. According to this issue, https://github.com/JuliaSIMD/LoopVectorization.jl/issues/19, the macro doesn't support complex numbers, but there is a workaround with `reinterpret` arrays that I attempted. 

Benchmark before this PR
<details>

```
julia> include("bz-integral/contdef1d/bench_Cont1DBZ.jl")
[ Info: Precompiling Cont1DBZ [top-level]
bench Cont1DBZ with M=1.
        Eval at 1000 targs...
evalh_ref:        58.891 μs (14 allocations: 212.69 KiB)
evalh_wind:       47.845 μs (6 allocations: 86.69 KiB)
evalh:            49.036 μs (13 allocations: 126.53 KiB)
evalh 0.0623532 G mode-targs/sec
        Quadr meths:
realadap ω=0.5 η=1e-06 tol=1e-08:    1.292 ms (36758 allocations: 2.53 MiB)
roots (matrix size 2M+1=3):    1.679 μs (21 allocations: 2.66 KiB)
imshcorr same ω and η as above, NPTR=30:     8.989 μs (56 allocations: 9.27 KiB)
bench Cont1DBZ with M=10.
        Eval at 1000 targs...
evalh_ref:        540.485 μs (86 allocations: 1.32 MiB)
evalh_wind:       76.605 μs (6 allocations: 86.69 KiB)
evalh:            56.991 μs (13 allocations: 126.81 KiB)
evalh 0.369543 G mode-targs/sec
        Quadr meths:
realadap ω=0.5 η=1e-06 tol=1e-08:    14.043 ms (265659 allocations: 23.49 MiB)
roots (matrix size 2M+1=21):    144.457 μs (21 allocations: 88.36 KiB)
imshcorr same ω and η as above, NPTR=30:     184.483 μs (137 allocations: 133.17 KiB)
bench Cont1DBZ with M=100.
        Eval at 1000 targs...
evalh_ref:        5.349 ms (806 allocations: 12.39 MiB)
evalh_wind:       364.559 μs (6 allocations: 86.69 KiB)
evalh:            148.156 μs (13 allocations: 129.91 KiB)
evalh 1.42891 G mode-targs/sec
        Quadr meths:
realadap ω=0.5 η=1e-06 tol=1e-08:    532.564 ms (2584482 allocations: 786.49 MiB)
roots (matrix size 2M+1=201):    56.349 ms (24 allocations: 1.95 MiB)
imshcorr same ω and η as above, NPTR=30:     55.931 ms (950 allocations: 4.57 MiB)
```

</details>

Benchmark with this PR
<details>

```
julia> include("bz-integral/contdef1d/bench_Cont1DBZ.jl")
[ Info: Precompiling Cont1DBZ [top-level]
[ Info: Precompiling BenchmarkTools [6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf]
bench Cont1DBZ with M=1.
        Eval at 1000 targs...
evalh_ref:        62.058 μs (14 allocations: 212.69 KiB)
evalh_wind:       35.308 μs (3 allocations: 47.25 KiB)
evalh:            34.703 μs (3 allocations: 47.25 KiB)
evalh 0.0866651 G mode-targs/sec
        Quadr meths:
realadap ω=0.5 η=1e-06 tol=1e-08:    420.903 μs (9428 allocations: 708.30 KiB)
roots (matrix size 2M+1=3):    1.709 μs (21 allocations: 2.66 KiB)
imshcorr same ω and η as above, NPTR=30:     8.400 μs (47 allocations: 7.03 KiB)
bench Cont1DBZ with M=10.
        Eval at 1000 targs...
evalh_ref:        565.902 μs (86 allocations: 1.32 MiB)
evalh_wind:       62.116 μs (3 allocations: 47.25 KiB)
evalh:            57.062 μs (3 allocations: 47.25 KiB)
evalh 0.369666 G mode-targs/sec
        Quadr meths:
realadap ω=0.5 η=1e-06 tol=1e-08:    6.394 ms (68829 allocations: 5.02 MiB)
roots (matrix size 2M+1=21):    144.387 μs (21 allocations: 88.36 KiB)
imshcorr same ω and η as above, NPTR=30:     185.901 μs (128 allocations: 130.66 KiB)
bench Cont1DBZ with M=100.
        Eval at 1000 targs...
evalh_ref:        5.410 ms (806 allocations: 12.39 MiB)
evalh_wind:       358.529 μs (3 allocations: 47.25 KiB)
evalh:            308.552 μs (3 allocations: 47.25 KiB)
evalh 0.651924 G mode-targs/sec
        Quadr meths:
realadap ω=0.5 η=1e-06 tol=1e-08:    524.736 ms (891672 allocations: 65.22 MiB)
roots (matrix size 2M+1=201):    56.158 ms (24 allocations: 1.95 MiB)
imshcorr same ω and η as above, NPTR=30:     58.984 ms (941 allocations: 4.57 MiB)
```

</details>

I hope this pr helps elucidate the sources of allocations, even though it doesn't improve the runtime of the `@avx`-accelerated routine. Perhaps there is a fix I am not aware of, and if there is I would want to include `@avx` in `AutoBZ.jl` routines.