### PR TITLE
support matrix coefficients in fourier series routines

### DIFF
--- a/contdef1d/Cont1DBZ.jl
+++ b/contdef1d/Cont1DBZ.jl
@@ -199,8 +199,8 @@ end
     use quadgk on Re axis to integrate 1/(ω - h(x) + iη).
     hm is given by offsetvector of Fourier series. tol controls rtol.
 """
-function realadap(hm,ω,η; tol=1e-8, verb=0)
-    f(x::Number) = tr(inv(complex(ω,η)*I - evalh(hm,x)))    # integrand func (quadgk gives x a number)
+function realadap(hm,ω,η; tol=1e-8, verb=0, kernel=evalh)
+    f(x::Number) = tr(inv(complex(ω,η)*I - kernel(hm,x)))    # integrand func (quadgk gives x a number)
     A,err = quadgk(f,0,2π,rtol=tol)          # can't get more info? # fevals?
     if verb>0
         @printf "\trealadap claimed err=%g\n" err
@@ -216,14 +216,7 @@ end
     hm is given by offsetvector of Fourier series. tol controls rtol.
     By LXVM.
 """
-function realadap_lxvm(hm, ω, η; tol=1e-8, verb=0)
-    f(x) = tr(inv(complex(ω,η)*I - fourier_kernel(hm,x)))
-    A,err = quadgk(f, 0.0, 2pi, rtol=tol)
-    verb>0 && @printf "\trealadap_lxvm claimed err=%g\n" err
-    A
-end
-
-
+realadap_lxvm(hm, ω, η; tol=1e-8, verb=0) = realadap(hm, ω, η; tol=tol, verb=verb, kernel=fourier_kernel)
 
 
 

--- a/contdef1d/bench_Cont1DBZ.jl
+++ b/contdef1d/bench_Cont1DBZ.jl
@@ -5,6 +5,7 @@
 push!(LOAD_PATH,".")
 using Cont1DBZ
 using OffsetArrays
+using StaticArrays
 using Printf
 
 using TimerOutputs
@@ -21,8 +22,9 @@ x = 2π*rand(1000)             # plain eval targs
 NPTR=30                       # fixed for now
 
 @printf "bench Cont1DBZ...\n"
-for M = [8,32,128]
-    local hm = OffsetVector(randn(ComplexF64,2M+1),-M:M)      # h(x)
+for M = [8,32,128], T in (ComplexF64, SMatrix{1,1,ComplexF64,1}, SMatrix{5,5,ComplexF64,25})
+    @timeit TIME string(T) begin
+    local hm = OffsetVector(randn(T,2M+1),-M:M)      # h(x)
     local hm = (hm + conj(reverse(hm)))/2                     # make h(x) real
     @timeit TIME @sprintf("M=%d (eval at %d targs)",M,length(x)) begin
         for i=1:10   # samples
@@ -31,6 +33,7 @@ for M = [8,32,128]
             TIME(evalh)(hm,x)
             TIME(fourier_kernel)(hm,x)    # note uses array version
         end
+        T<:Number || continue # for now skip root-finding for matrix coefficients
         coeffs = reverse(hm.parent)
         @timeit TIME @sprintf("root-finding (matrix size 2M+1=%d)",2M+1) begin
             r = TIME(roots)(coeffs)
@@ -43,6 +46,7 @@ for M = [8,32,128]
             AI = @timeit TIME @sprintf("imshcorr(NPTR=%d)",NPTR) imshcorr(hm,ω,η,N=NPTR)
         end
         println(A,'\n',AL,'\n',AI)   # check integrals match
+    end
     end
 end
 print_timer(TIME, sortby=:firstexec)   # use sortby otherwise randomizes order!

--- a/contdef1d/btime_Cont1DBZ.jl
+++ b/contdef1d/btime_Cont1DBZ.jl
@@ -17,9 +17,10 @@ x = 2π*rand(1000)
 η=1e-6; ω=0.5; tol=1e-8;
 NPTR=30
 
-for M = [8,32,128]   # M=1 is silly here
+for M = [8,32,128], T in (ComplexF64, SMatrix{1,1,ComplexF64,1}, SMatrix{5,5,ComplexF64,25})   # M=1 is silly here
+    println(T)
     @printf "\nbench Cont1DBZ with M=%d.\n\tEval at %d targs...\n" M length(x)
-    local hm = OffsetVector(randn(ComplexF64,2M+1),-M:M)      # h(x)
+    local hm = OffsetVector(randn(T,2M+1),-M:M)      # h(x)
     local hm = (hm + conj(reverse(hm)))/2                     # make h(x) real
     @printf "evalh_ref:\t"
     @btime evalh_ref($hm,$x)
@@ -31,6 +32,7 @@ for M = [8,32,128]   # M=1 is silly here
     @printf "evalh %g G mode-targs/sec\n" (2M+1)*length(x)/t_ns
     @printf "fourier_kernel:    \t"
     @btime map(x -> fourier_kernel($hm,x), $x)
+    T<:Number || continue # for now skip root-finding for matrix coefficients
     
     @printf "\tQuadr meths:\nrealadap ω=%g η=%g tol=%g:  " ω η tol
     @btime realadap($hm,ω,η,tol=tol)

--- a/contdef1d/test_Cont1DBZ.jl
+++ b/contdef1d/test_Cont1DBZ.jl
@@ -27,23 +27,24 @@ Hm = (Hm + reverse(Hmconj))/2                           # H(x) hermitian if x Re
 
 # test eval for x a scalar, vector, real, complex (each an el of tuple)...
 nx = 1000
-xtest = (1.9, [1.3], 2π*rand(nx), 2π*rand(nx)+im*rand(nx))
-for t=1:length(xtest)
+xtest = (1.9, [1.3], 2π*rand(nx), 2π*rand(ComplexF64, nx))
+for (t,x) in enumerate(xtest)
     @printf "scalar evalh variants consistency: test #%d...\n" t
-    local x = xtest[t]
     if t==1
         @printf "\tevalh @ x=%g: " x; println(evalh(hm,x))
     end
-    @printf "evalh chk:          %.3g\n" norm(evalh(hm,x) .- evalh_ref(hm,x),Inf)
-    @printf "evalh_wind chk:     %.3g\n" norm(evalh_wind(hm,x) .- evalh_ref(hm,x),Inf)
-    @printf "fourier_kernel chk: %.3g\n" norm(fourier_kernel.(Ref(hm),x) .- evalh_ref(hm,x),Inf)
+    @printf "evalh chk:          %.3g\n" norm(evalh(hm,x) - evalh_ref(hm,x),Inf)
+    @printf "evalh_wind chk:     %.3g\n" norm(evalh_wind(hm,x) - evalh_ref(hm,x),Inf)
+    @printf "fourier_kernel chk: %.3g\n" norm(fourier_kernel.(Ref(hm),x) - evalh_ref(hm,x),Inf)
     @printf "matrix evalH variants consistency: test #%d...\n" t
-    H = evalH_ref(Hm,x)
+    H = evalh_ref(Hm,x)
     if t<=2
-        @printf "evalH_ref simply check is Herm: %.3g\n" norm(H-H',Inf)
+        @printf "evalH_ref simply check is Herm: %.3g\n" norm(H - adjoint.(H),Inf)
     end
     # *** matrix evalH tests
-
+    @printf "evalH chk:          %.3g\n" norm(evalh(Hm,x) - evalh_ref(Hm,x),Inf)
+    @printf "evalH_wind chk:     %.3g\n" norm(evalh_wind(Hm,x) - evalh_ref(Hm,x),Inf)
+    @printf "fourier_kernel chk: %.3g\n" norm(fourier_kernel.(Ref(Hm),x) - evalh_ref(Hm,x),Inf)
     
 end
 
@@ -52,7 +53,7 @@ end
 Aa = realadap(hm,ω,η,tol=tol, verb=1)
 @printf "\tAa = "; println(Aa)
 @printf "test realadapmat for n=%d M=%d ω=%g η=%g tol=%g...\n" n M ω η tol
-Aan = realadapmat(Hm,ω,η,tol=tol, verb=1)
+Aan = realadap(Hm,ω,η,tol=tol, verb=1)
 @printf "\tAan = "; println(Aan)
 
 # *** continue with roots via NEVP...


### PR DESCRIPTION
This PR extends the Fourier series evaluators with methods to evaluate series with matrix-valued coefficients. Making this behavior work is tricky alongside accepting evaluation points as numbers and vectors, so in some cases I added new methods to make the behavior unambiguous or better for performance